### PR TITLE
Modified tokenId to be a string

### DIFF
--- a/server/docs/index.md
+++ b/server/docs/index.md
@@ -533,6 +533,7 @@ URL: http://127.0.0.1/livecopycert/
 | Key     | Value  | Description |
 | ------- | ------ | ----------- |
 | TokenId | INV002 |             |
+| GroupId | IOCL   |             |
 
 **_More example Requests/Responses:_**
 
@@ -543,6 +544,7 @@ URL: http://127.0.0.1/livecopycert/
 | Key     | Value  | Description |
 | ------- | ------ | ----------- |
 | TokenId | INV002 |             |
+| GroupId | IOCL   |             |
 
 ##### I. Example Response: Get Cert - 200 OK
 

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
     "start": "node ./src/index.js",
     "test": "npm run test:unit && npm run test:integration",
     "test:unit": "mocha --recursive --timeout 40000 --exit test/unit/**/*.js",
-    "test:integration": "mocha --recursive --timeout 150000 --exit test/integration/**/*.js"
+    "test:integration": "mocha --recursive --timeout 150000 --retries 2 --exit test/integration/**/*.js"
   },
   "dependencies": {
     "@taquito/signer": "^7.0.0-beta.0",

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -37,8 +37,8 @@ const NETWORK_CONFIG = {
       network: "delphinet",
     },
     contractAddresses: {
-      groupFactoryAddress: "KT1SwLaJvQcHcduX1nMEfKoDMAYVU9ipb59t",
-      nftAddress: "KT1X2uyKBAFnH7nU48AAqy1KncipwdubdCCB",
+      groupFactoryAddress: "KT1CRMPWzgPGK4GbakV5kjnvteWVwCRHLNQr",
+      nftAddress: "KT1AFbkeGkqKppzFYuBiphCStQ3jrmu5eDri",
     },
     networkId: "NetXm8tYqnMWky1",
   },

--- a/server/src/controllers/livecopy-nft/index.js
+++ b/server/src/controllers/livecopy-nft/index.js
@@ -45,14 +45,14 @@ const issueCert = async function (req, res) {
     }
 
     // TokenId validations
-    if (TokenId === null || TokenId === undefined) {
+    if (!TokenId) {
       return sendBadRequestErrMessage(
         res,
         "Missing parameter TokenId in request"
       );
     }
-    if (typeof TokenId !== "number") {
-      return sendBadRequestErrMessage(res, "TokenId should be a valid number");
+    if (typeof TokenId !== "string") {
+      return sendBadRequestErrMessage(res, "TokenId should be a valid string");
     }
 
     // Hash validations
@@ -151,7 +151,7 @@ const issueCert = async function (req, res) {
 // Get details of nft from smart contract
 const getCert = async function (req, res) {
   try {
-    const { TokenId } = req.query;
+    const { TokenId, GroupId } = req.query;
     if (!TokenId) {
       return sendBadRequestErrMessage(
         res,
@@ -159,8 +159,19 @@ const getCert = async function (req, res) {
       );
     }
 
+    if (!GroupId) {
+      return sendBadRequestErrMessage(
+        res,
+        "Missing parameter GroupId in request"
+      );
+    }
+
+    const livecopyGroupFactory = req.app.get("livecopyGroupFactory");
+    const livecopyGroup = await livecopyGroupFactory.getGroupInstance(GroupId);
+    const internalTokenId = await livecopyGroup.getTokenId(TokenId);
+
     const livecopyNft = req.app.get("livecopyNft");
-    const tokenDetails = await livecopyNft.getTokenData(TokenId);
+    const tokenDetails = await livecopyNft.getTokenData(internalTokenId);
     return res.status(200).send({
       status: "success",
       code: 200,

--- a/server/src/services/livecopy-group/livecopy-group.js
+++ b/server/src/services/livecopy-group/livecopy-group.js
@@ -124,6 +124,23 @@ class LiveCopyGroup {
   }
 
   /**
+   * Return the id corresponding to a string tokenSymbol
+   * @param {string} tokenSymbol
+   * 
+   * @returns {string}
+   */
+  async getTokenId(tokenSymbol) {
+    const { tokensIssued } = await this.groupContract.storage();
+
+    const tokenId = await tokensIssued.get(tokenSymbol);
+    if (tokenId === null || tokenId === undefined) {
+      throw new ValidationError("TokenId not found");
+    }
+
+    return tokenId.toString();
+  }
+
+  /**
    * Issue an NFT Cert
    *
    * @param {number} tokenId
@@ -176,13 +193,13 @@ class LiveCopyGroup {
     const issueCertificateMethod = this.groupContract.methods["issueCert"](
       assetType,
       documentHash,
-      signerPublicKey,
-      signature,
       signerAddress,
+      signature,
+      signerPublicKey,
       state,
       issuedToAlias,
-      documentUrl,
-      tokenId
+      tokenId,
+      documentUrl
     );
     const transferParams = issueCertificateMethod.toTransferParams();
     const transactionHash = await this.relayer.sendContractInvocation(

--- a/server/src/services/livecopy-nft/index.js
+++ b/server/src/services/livecopy-nft/index.js
@@ -17,7 +17,7 @@ class LiveCopyNft {
 
   /**
    * Returns token data from a tokenId
-   * @param {string} tokenId
+   * @param {number} tokenId
    *
    * @returns {object}
    */

--- a/server/test/integration/livecopy.test.js
+++ b/server/test/integration/livecopy.test.js
@@ -26,7 +26,7 @@ describe("Livecopy integration test", () => {
       "edpktzrjdb1tx6dQecQGZL6CwhujWg1D2CXfXWBriqtJSA6kvqMwA2",
     groupId = faker.company.companyName(),
     minSignaturesReqd = 1,
-    tokenId = faker.random.number();
+    tokenId = faker.random.word();
 
   let mongoConnection;
   let groupAdminAddress, groupAdminPublicKey, groupAdminSecretKey;
@@ -556,7 +556,7 @@ describe("Livecopy integration test", () => {
     });
 
     it("should throw error on invalid signature", async function () {
-      const tokenId = faker.random.number();
+      const tokenId = faker.random.word();
       const signature = faker.random.hexaDecimal(32);
 
       const requestWithInvalidSignature = {
@@ -584,7 +584,6 @@ describe("Livecopy integration test", () => {
     it("should throw error if to address is not whitelisted", async function () {
       const signature = await sign(packString(hash), signerSecretKey);
 
-      // TODO:
       issueTokenRequest.TokenOwner = faker.name.firstName();
       issueTokenRequest.signature = signature;
 
@@ -608,7 +607,7 @@ describe("Livecopy integration test", () => {
   describe("fetch nft details test cases", function () {
     it("should get nft details with status 200", async function () {
       const res = await testSuite
-        .get(`/livecopycert/?TokenId=${tokenId}`)
+        .get(`/livecopycert/?TokenId=${tokenId}&GroupId=${groupId}`)
         .set("Accept", "application/json")
         .expect("Content-Type", /json/)
         .expect(200);
@@ -646,7 +645,7 @@ describe("Livecopy integration test", () => {
       const invalidTokenId = faker.random.number();
 
       const res = await testSuite
-        .get(`/livecopycert/?TokenId=${invalidTokenId}`)
+        .get(`/livecopycert/?TokenId=${invalidTokenId}&GroupId=${groupId}`)
         .set("Accept", "application/json")
         .expect("Content-Type", /json/)
         .expect(400);


### PR DESCRIPTION
TokenID can now be a string. And also, same tokenId can be created from a different group. The uniqueness condition applies only within a group.

Owing to these changes, `getCert` API now requires a `groupId` in the query parameter, in addition to `tokenId`.

[Get Cert API](https://github.com/koinearth/marketsn-livecopy-tz/blob/fcbd216b10f0b4c27d61ab88b01dbe9a6d8b619a/server/docs/index.md#2-get-cert)

**Clickup Tasks:** [Refer to point 3, 7](https://doc.clickup.com/d/h/3k6k5-88/e11e32ee3cf4bdd)