### PR TITLE
Fix: Acct not available during gas estd

### DIFF
--- a/server/src/config.js
+++ b/server/src/config.js
@@ -27,6 +27,7 @@ const NETWORK_CONFIG = {
       nftAddress: "",
     },
     networkId: "NetXdQprcVkpaWU",
+    blockTimeInMs: 60000
   },
   delphinet: {
     rpc: "https://delphinet-tezos.giganode.io",
@@ -41,6 +42,7 @@ const NETWORK_CONFIG = {
       nftAddress: "KT1AFbkeGkqKppzFYuBiphCStQ3jrmu5eDri",
     },
     networkId: "NetXm8tYqnMWky1",
+    blockTimeInMs: 30000
   },
 };
 
@@ -58,6 +60,7 @@ const config = {
   noOfConfirmations: NETWORK_CONFIG[NETWORK].noOfConfirmations,
   conseilServer: NETWORK_CONFIG[NETWORK].conseilServer,
   contractAddresses: NETWORK_CONFIG[NETWORK].contractAddresses,
+  blockTimeInMs: NETWORK_CONFIG[NETWORK].blockTimeInMs,
 
   relayerSecretKeys,
 

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -26,7 +26,11 @@ async function initialize() {
   );
 
   logger.info("initializing relayers ...");
-  const relayer = await initializeRelayers(rpc, config.relayerSecretKeys);
+  const relayer = await initializeRelayers(
+    rpc,
+    config.relayerSecretKeys,
+    config.blockTimeInMs
+  );
 
   logger.info("initializing livecopy ...");
   const livecopyGroupFactory = await initializeLiveCopyGroupFactory(

--- a/server/src/services/relayer/index.js
+++ b/server/src/services/relayer/index.js
@@ -22,18 +22,20 @@ class Relayer {
    * Relayers for sending signed transactions of a different user
    * @param {TezosRPC} tezosRpc
    * @param {Object} relayerAccounts
+   * @param {number} blockTime
    */
-  constructor(tezosRpc, relayerAccounts) {
+  constructor(tezosRpc, relayerAccounts, blockTime) {
     this.tezosRpc = tezosRpc;
     this.availableAccounts = relayerAccounts;
 
     this.availableGasLimit = MAX_GAS_LIMIT;
     this.availableStorageLimit = MAX_STORAGE_LIMIT_IN_BYTES;
     this.operations = [];
-    this.batchTimeout = 30000 / this.availableAccounts.length;
+    this.batchTimeout = blockTime / this.availableAccounts.length;
 
     // Gas estd. in Tezos needs a valid acct.
     this.gasEstimationAccount = Object.assign({}, relayerAccounts[0]);
+    this.isBatchScheduled = false;
   }
 
   _chooseRelayer() {
@@ -70,7 +72,6 @@ class Relayer {
       transferParams
     );
 
-    // Errored, throw back err, add relayer as available and return
     if (error) {
       throw new TransactionError(error);
     }
@@ -84,8 +85,8 @@ class Relayer {
     }
 
     // Schedule batch
-    if (this.operations.length === 0) {
-      setTimeout(this.sendOperationsBatch.bind(this), this.batchTimeout);
+    if (!this.isBatchScheduled) {
+      this._scheduleBatch();
     }
 
     // Queue operation
@@ -95,6 +96,8 @@ class Relayer {
       id,
       transferParams,
     });
+    this.availableGasLimit -= gasCost;
+    this.availableStorageLimit -= storageCost;
 
     // Success, save txn details to db with status as pending
     const transaction = new transactionsModel({
@@ -107,18 +110,53 @@ class Relayer {
     return id;
   }
 
-  async sendOperationsBatch() {
+  _scheduleBatch() {
+    if (!this.isBatchScheduled) {
+      setTimeout(this._processOperationQueue.bind(this), this.batchTimeout);
+      this.isBatchScheduled = true;
+    }
+  }
+
+  async _processOperationQueue() {
+    if (this.operations.length === 0) {
+      console.log("No pending operations");
+      return;
+    }
+
     const relayer = this._chooseRelayer();
     if (!relayer) {
-      throw new Error(
+      console.log(
         "No proxy account available for executing transaction;" +
           "All are currently busy carrying out transactions"
       );
+      this.isBatchScheduled = false;
+      this._scheduleBatch();
+      return;
     }
 
     const operationsToSend = Object.assign([], this.operations);
     this.operations = [];
 
+    this._batchAndSend(operationsToSend, relayer);
+    this.availableStorageLimit = MAX_STORAGE_LIMIT_IN_BYTES;
+    this.availableGasLimit = MAX_GAS_LIMIT;
+    this.isBatchScheduled = false;
+  }
+
+  async _batchAndSend(operationsToSend, relayer) {
+    try {
+      const { batch, ids } = await this._prepareOperationBatch(
+        relayer,
+        operationsToSend
+      );
+      const op = await this._broadcastOperationBatch(batch, ids);
+      await this._checkConfimation(op, ids);
+    } finally {
+      this._addBackRelayer(relayer);
+    }
+  }
+
+  async _prepareOperationBatch(relayer, operationsToSend) {
     const context = new Context(
       this.tezosRpc.rpcURL,
       new InMemorySigner(relayer.secretKey)
@@ -142,18 +180,34 @@ class Relayer {
         console.log(error);
         const errorMessage = error.message || error.id;
         logger.error(`ID: ${currOp.id} failed with error: ${errorMessage}`);
-        await this._updateTransactionStatus([currOp.id], "failed", errorMessage);
+        await this._updateTransactionStatus(
+          [currOp.id],
+          "failed",
+          errorMessage
+        );
       }
     }
 
-    try {
-      const op = await batch.send();
-      const { opHash } = op;
-      logger.info(`Transaction hash: ${opHash}`);
-      await this._updateTransactionHash(ids, opHash);
+    return {
+      batch,
+      ids,
+    };
+  }
 
-      await op.confirmation();
-      await this._updateTransactionStatus(ids, "success");
+  async _broadcastOperationBatch(batch, ids) {
+    const op = await batch.send();
+    const { opHash } = op;
+    logger.info(`Transaction hash: ${opHash}`);
+    await this._updateTransactionHash(ids, opHash);
+    return op;
+  }
+
+  async _checkConfimation(op, ids) {
+    try {
+      const { completed, isInCurrentBranch } = await op.confirmation();
+      const txnApplied = await isInCurrentBranch();
+      const status = txnApplied && completed ? "success" : "failed";
+      await this._updateTransactionStatus(ids, status);
     } catch (error) {
       console.log(error);
       if (error instanceof TezosOperationError) {
@@ -163,11 +217,10 @@ class Relayer {
       }
 
       await this._updateTransactionStatus(ids, "failed");
-    } finally {
-      this._addBackRelayer(relayer);
     }
   }
 
+  // Update transaction hash corr to txn ids in db
   async _updateTransactionHash(ids, opHash) {
     let dbOps = ids.map((id) => {
       return {
@@ -209,7 +262,7 @@ class Relayer {
  *
  * @returns {Promise<Relayer>}
  */
-async function initializeRelayers(tezosRpc, privateKeys) {
+async function initializeRelayers(tezosRpc, privateKeys, blockTime) {
   const accounts = [];
   for (const key of privateKeys) {
     const accountInfo = await getAccountInfo(key);
@@ -219,7 +272,7 @@ async function initializeRelayers(tezosRpc, privateKeys) {
     accounts.push(accountInfo);
   }
 
-  return new Relayer(tezosRpc, accounts);
+  return new Relayer(tezosRpc, accounts, blockTime);
 }
 
 module.exports = { initializeRelayers, Relayer };

--- a/server/src/services/relayer/index.js
+++ b/server/src/services/relayer/index.js
@@ -31,6 +31,9 @@ class Relayer {
     this.availableStorageLimit = MAX_STORAGE_LIMIT_IN_BYTES;
     this.operations = [];
     this.batchTimeout = 30000 / this.availableAccounts.length;
+
+    // Gas estd. in Tezos needs a valid acct.
+    this.gasEstimationAccount = Object.assign({}, relayerAccounts[0]);
   }
 
   _chooseRelayer() {
@@ -63,7 +66,7 @@ class Relayer {
       storageCost,
       gasCost,
     } = await this.tezosRpc.testContractInvocation(
-      this.availableAccounts[0].secretKey,
+      this.gasEstimationAccount.secretKey,
       transferParams
     );
 


### PR DESCRIPTION
**Purpose:** While queuing an operation, the txn is dry run using an activated account. Seems there is an issue of account not available, during the gas estd. 

```
TypeError: Cannot read property `secretKey` of undefined
```

I've tested for around 200 txns using the latest code and didn't encounter any issues. Hopefully this PR should fix the issues.